### PR TITLE
update maven url's to work

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -100,7 +100,7 @@
 
     <property name="ivy.version" value="2.2.0"/>
     <property name="ivy.url"
-              value="http://repo2.maven.org/maven2/org/apache/ivy/ivy" />
+              value="https://repo.maven.apache.org/maven2/org/apache/ivy/ivy" />
     <property name="ivy.home" value="${user.home}/.ant" />
     <property name="ivy.lib" value="${build.dir}/lib"/>
     <property name="ivy.package.lib" value="${build.dir}/package/lib"/>

--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -18,11 +18,11 @@
 -->
 
   <property name="repo.maven.org"
-    value="http://repo1.maven.org/maven2/" override="false"/>
+    value="https://repo.maven.apache.org/maven2/" override="false"/>
   <property name="repo.jboss.org"
-    value="http://repository.jboss.org/nexus/content/groups/public/" override="false"/>
+    value="https://repository.jboss.org/nexus/content/groups/public/" override="false"/>
   <property name="repo.sun.org"
-    value="http://download.java.net/maven/2/" override="false"/>
+    value="https://download.java.net/maven/2/" override="false"/>
   <property name="maven2.pattern"
     value="[organisation]/[module]/[revision]/[module]-[revision]"/>
   <property name="maven2.pattern.ext" value="${maven2.pattern}.[ext]"/>

--- a/src/contrib/build-contrib.xml
+++ b/src/contrib/build-contrib.xml
@@ -43,7 +43,7 @@
 
   <property name="ivy.version" value="2.2.0"/>
   <property name="ivy.url"
-            value="http://repo2.maven.org/maven2/org/apache/ivy/ivy" />
+            value="https://repo.maven.apache.org/maven2/org/apache/ivy/ivy" />
   <property name="ivy.home" value="${user.home}/.ant" />
   <property name="ivy.lib" value="${build.dir}/lib"/>
   <property name="ivy.test.lib" value="${build.test}/lib"/>


### PR DESCRIPTION
Maven generally requires https url's now, and repo2 is gone.